### PR TITLE
Feature/structured concurrency conformance

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,21 @@
 
 import PackageDescription
 
+let swiftSettings: [SwiftSetting] = [
+   .enableUpcomingFeature("BareSlashRegexLiterals"),
+   .enableUpcomingFeature("ConciseMagicFile"),
+   .enableUpcomingFeature("ExistentialAny"),
+   .enableUpcomingFeature("ForwardTrailingClosures"),
+   .enableUpcomingFeature("ImplicitOpenExistentials"),
+   .enableUpcomingFeature("StrictConcurrency"),
+   .enableUpcomingFeature("IsolatedDefaultValues"),
+   .enableUpcomingFeature("GlobalConcurrency"),
+   .enableUpcomingFeature("InferSendableFromCaptures"),
+   .enableUpcomingFeature("RegionBasedIsolation"),
+   .unsafeFlags(["-warn-concurrency",
+                 "-enable-actor-data-race-checks"])
+]
+
 let package = Package(
     name: "Factory",
     platforms: [
@@ -28,7 +43,9 @@ let package = Package(
         .target(
             name: "Factory",
             dependencies: [],
-            resources: [.copy("PrivacyInfo.xcprivacy")]),
+            resources: [.copy("PrivacyInfo.xcprivacy")],
+            swiftSettings: swiftSettings
+        ),
         .testTarget(
             name: "FactoryTests",
             dependencies: ["Factory"]),

--- a/Sources/Factory/Factory/Containers.swift
+++ b/Sources/Factory/Factory/Containers.swift
@@ -110,7 +110,7 @@ extension ManagedContainer {
         Factory<T?>(self, key: key) {
             #if DEBUG
             if self.manager.promiseTriggersError {
-                resetAndTriggerFatalError("\(T.self) was not registered", #file, #line)
+                GlobalFactoryVariables.shared.resetAndTriggerFatalError("\(T.self) was not registered", #file, #line)
             } else {
                 return nil
             }
@@ -124,7 +124,7 @@ extension ManagedContainer {
         ParameterFactory<P,T?>(self, key: key) { _ in
             #if DEBUG
             if self.manager.promiseTriggersError {
-                resetAndTriggerFatalError("\(T.self) was not registered", #file, #line)
+                GlobalFactoryVariables.shared.resetAndTriggerFatalError("\(T.self) was not registered", #file, #line)
             } else {
                 return nil
             }
@@ -176,14 +176,14 @@ public final class ContainerManager {
 
     /// Public var enabling factory resolution trace statements in debug mode for ALL containers.
     public var trace: Bool {
-        get { globalTraceFlag }
-        set { globalTraceFlag = newValue }
+        get { GlobalFactoryVariables.shared.globalTraceFlag }
+        set { GlobalFactoryVariables.shared.globalTraceFlag = newValue }
     }
 
     /// Public access to logging facility in debug mode for ALL containers.
     public var logger: (String) -> Void {
-        get { globalLogger }
-        set { globalLogger = newValue }
+        get { GlobalFactoryVariables.shared.globalLogger }
+        set { GlobalFactoryVariables.shared.globalLogger = newValue }
     }
 
     internal func isEmpty(_ options: FactoryResetOptions) -> Bool {

--- a/Sources/Factory/Factory/Containers.swift
+++ b/Sources/Factory/Factory/Containers.swift
@@ -205,7 +205,7 @@ public final class ContainerManager {
     #endif
 
     /// Alias for Factory registration map.
-    internal typealias FactoryMap = [FactoryKey:AnyFactory]
+    internal typealias FactoryMap = [FactoryKey:any AnyFactory]
     /// Alias for Factory options map.
     internal typealias FactoryOptionsMap = [FactoryKey:FactoryOptions]
     /// Alias for Factory once set.
@@ -325,7 +325,7 @@ extension ManagedContainer {
         if manager.autoRegistrationCheckNeeded {
             manager.autoRegistrationCheckNeeded = false
             manager.autoRegistering = true
-            (self as? AutoRegistering)?.autoRegister()
+            (self as? (any AutoRegistering))?.autoRegister()
             manager.autoRegistering = false
         }
     }

--- a/Sources/Factory/Factory/Factory.swift
+++ b/Sources/Factory/Factory/Factory.swift
@@ -72,7 +72,7 @@ public struct Factory<T>: FactoryModifying {
     ///   current container as well defining the scope.
     ///   - key: Hidden value used to differentiate different instances of the same type in the same container.
     ///   - factory: A factory closure that produces an object of the desired type when required.
-    public init(_ container: ManagedContainer, key: StaticString = #function, _ factory: @escaping () -> T) {
+    public init(_ container: any ManagedContainer, key: StaticString = #function, _ factory: @escaping () -> T) {
         self.registration = FactoryRegistration<Void,T>(key: key, container: container, factory: factory)
     }
 
@@ -198,7 +198,7 @@ public struct ParameterFactory<P,T>: FactoryModifying {
     ///   current container as well defining the scope.
     ///   - key: Hidden value used to differentiate different instances of the same type in the same container.
     ///   - factory: A factory closure that produces an object of the desired type when required.
-    public init(_ container: ManagedContainer, key: StaticString = #function, _ factory: @escaping (P) -> T) {
+    public init(_ container: any ManagedContainer, key: StaticString = #function, _ factory: @escaping (P) -> T) {
         self.registration = FactoryRegistration<P,T>(key: key, container: container, factory: factory)
     }
 

--- a/Sources/Factory/Factory/Globals.swift
+++ b/Sources/Factory/Factory/Globals.swift
@@ -26,34 +26,90 @@
 
 import Foundation
 
-// MARK: - Internal Variables
-
-/// Master graph resolution depth counter
-internal var globalGraphResolutionDepth = 0
-
-/// Internal key used for Resolver mode
-internal var globalResolverKey: StaticString = "*"
+ //MARK: - Internal Variables
 
 #if DEBUG
-/// Internal variables used for debugging
-internal var globalDependencyChain: [String] = []
-internal var globalDependencyChainMessages: [String] = []
-internal var globalTraceFlag: Bool = false
-internal var globalTraceResolutions: [String] = []
-internal var globalLogger: (String) -> Void = { print($0) }
-internal var globalDebugInformationMap: [FactoryKey:FactoryDebugInformation] = [:]
-
-/// Triggers fatalError after resetting enough stuff so unit tests can continue
-internal func resetAndTriggerFatalError(_ message: String, _ file: StaticString, _ line: UInt) -> Never {
-    globalDependencyChain = []
-    globalDependencyChainMessages = []
-    globalGraphResolutionDepth = 0
-    globalRecursiveLock = RecursiveLock()
-    globalTraceResolutions = []
-    triggerFatalError(message, file, line) // GOES BOOM
-}
-
 /// Allow unit test interception of any fatal errors that may occur running the circular dependency check
 /// Variation of solution: https://stackoverflow.com/questions/32873212/unit-test-fatalerror-in-swift#
 internal var triggerFatalError = Swift.fatalError
 #endif
+
+
+internal final class GlobalFactoryVariables: @unchecked Sendable {
+    private var _globalGraphResolutionDepth = 0
+    private var _globalResolverKey: StaticString = "*"
+    private let lock = NSLock()
+
+    #if DEBUG
+
+    /// Internal variables used for debugging
+    private var _globalDependencyChain: [String] = []
+    private var _globalDependencyChainMessages: [String] = []
+    private var _globalTraceFlag: Bool = false
+    private var _globalTraceResolutions: [String] = []
+    private var _globalLogger: (String) -> Void = { print($0) }
+    private var _globalDebugInformationMap: [FactoryKey:FactoryDebugInformation] = [:]
+    
+    /// Triggers fatalError after resetting enough stuff so unit tests can continue
+    internal func resetAndTriggerFatalError(_ message: String, _ file: StaticString, _ line: UInt) -> Never {
+        globalDependencyChain = []
+        globalDependencyChainMessages = []
+        globalGraphResolutionDepth = 0
+        globalRecursiveLock = RecursiveLock()
+        globalTraceResolutions = []
+        triggerFatalError(message, file, line) // GOES BOOM
+    }
+    #endif
+ 
+    static let shared = GlobalFactoryVariables()
+    
+    private init() {}
+    
+    var globalGraphResolutionDepth: Int {
+        get { lock.synchronized { _globalGraphResolutionDepth } }
+        set { lock.synchronized { _globalGraphResolutionDepth = newValue } }
+    }
+
+    var globalResolverKey: StaticString {
+        get { lock.synchronized { _globalResolverKey } }
+        set { lock.synchronized { _globalResolverKey = newValue } }
+    }
+    
+    var globalDependencyChain: [String] {
+        get { lock.synchronized { _globalDependencyChain } }
+        set { lock.synchronized { _globalDependencyChain = newValue } }
+    }
+    
+    var globalDependencyChainMessages: [String] {
+        get { lock.synchronized { _globalDependencyChainMessages } }
+        set { lock.synchronized { _globalDependencyChainMessages = newValue } }
+    }
+    
+    var globalTraceFlag: Bool {
+        get { lock.synchronized { _globalTraceFlag } }
+        set { lock.synchronized { _globalTraceFlag = newValue } }
+    }
+    
+     var globalTraceResolutions: [String] {
+        get { lock.synchronized { _globalTraceResolutions } }
+        set { lock.synchronized { _globalTraceResolutions = newValue } }
+    }
+    
+     var globalLogger: (String) -> Void {
+        get { lock.synchronized { _globalLogger } }
+        set { lock.synchronized { _globalLogger = newValue } }
+    }
+    
+     var globalDebugInformationMap: [FactoryKey: FactoryDebugInformation] {
+        get { lock.synchronized { _globalDebugInformationMap } }
+        set { lock.synchronized { _globalDebugInformationMap = newValue } }
+    }
+}
+
+private extension NSLock {
+    func synchronized<T>(_ action: () -> T) -> T {
+        self.lock()
+        defer { self.unlock() }
+        return action()
+    }
+}

--- a/Sources/Factory/Factory/Injections.swift
+++ b/Sources/Factory/Factory/Injections.swift
@@ -125,8 +125,8 @@ import SwiftUI
     /// Manages the wrapped dependency, which is resolved when this value is accessed for the first time.
     public var wrappedValue: T {
         mutating get {
-            defer { globalRecursiveLock.unlock()  }
-            globalRecursiveLock.lock()
+            defer { RecursiveLockManager.shared.unlock()  }
+            RecursiveLockManager.shared.lock()
             if initialize {
                 resolve()
             }
@@ -209,8 +209,8 @@ import SwiftUI
     /// Manages the wrapped dependency, which is resolved when this value is accessed for the first time.
     public var wrappedValue: T? {
         mutating get {
-            defer { globalRecursiveLock.unlock()  }
-            globalRecursiveLock.lock()
+            defer { RecursiveLockManager.shared.unlock()  }
+            RecursiveLockManager.shared.lock()
             if initialize {
                 resolve()
             }

--- a/Sources/Factory/Factory/Injections.swift
+++ b/Sources/Factory/Factory/Injections.swift
@@ -48,7 +48,7 @@ import SwiftUI
 /// the referenced dependencies will be acquired when the parent class is created.
 @propertyWrapper public struct Injected<T> {
 
-    private var reference: BoxedFactoryReference
+    private var reference: any BoxedFactoryReference
     private var dependency: T
 
     /// Initializes the property wrapper. The dependency is resolved on initialization.
@@ -106,7 +106,7 @@ import SwiftUI
 /// > Note: Lazy injection is resolved the first time the dependency is referenced by the code, and **not** on initialization.
 @propertyWrapper public struct LazyInjected<T> {
     
-    private var reference: BoxedFactoryReference
+    private var reference: any BoxedFactoryReference
     private var dependency: T!
     private var initialize = true
     
@@ -190,7 +190,7 @@ import SwiftUI
 /// > Note: Lazy injection is resolved the first time the dependency is referenced by the code, **not** on initialization.
 @propertyWrapper public struct WeakLazyInjected<T> {
     
-    private var reference: BoxedFactoryReference
+    private var reference: any BoxedFactoryReference
     private weak var dependency: AnyObject?
     private var initialize = true
     
@@ -258,11 +258,11 @@ import SwiftUI
     private var dependency: T?
     /// Initializes the property wrapper from the default Container. The dependency is resolved on initialization.
     public init() {
-        self.dependency = (Container.shared as? Resolving)?.resolve()
+        self.dependency = (Container.shared as? (any Resolving))?.resolve()
     }
     /// Initializes the property wrapper from the default Container. The dependency is resolved on initialization.
-    public init(_ container: ManagedContainer) {
-        self.dependency = (container as? Resolving)?.resolve()
+    public init(_ container: any ManagedContainer) {
+        self.dependency = (container as? (any Resolving))?.resolve()
     }
     /// Manages the wrapped dependency.
     public var wrappedValue: T? {

--- a/Sources/Factory/Factory/NSLock+Extensions.swift
+++ b/Sources/Factory/Factory/NSLock+Extensions.swift
@@ -1,0 +1,36 @@
+//
+// NSLock+Extensions.swift
+//
+// GitHub Repo and Documentation: https://github.com/hmlongco/Factory
+//
+// Copyright © 2022 Michael Long. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+import Foundation
+
+extension NSLock {
+    func synchronized<T>(_ action: () -> T) -> T {
+        lock()
+        defer { unlock() }
+        return action()
+    }
+}
+

--- a/Sources/Factory/Factory/Resolver.swift
+++ b/Sources/Factory/Factory/Resolver.swift
@@ -49,8 +49,8 @@ extension Resolving {
     /// Also returns Factory for further specialization for scopes, decorators, etc.
     @discardableResult
     public func register<T>(_ type: T.Type = T.self, factory: @escaping () -> T) -> Factory<T> {
-        defer { globalRecursiveLock.unlock() }
-        globalRecursiveLock.lock()
+        defer { RecursiveLockManager.shared.unlock() }
+        RecursiveLockManager.shared.lock()
         // Perform autoRegistration check
         unsafeCheckAutoRegistration()
         // Add register to persist in container, and return factory so user can specialize if desired
@@ -62,8 +62,8 @@ extension Resolving {
     ///
     /// Note that nothing will be applied if initial registration is not found.
     public func factory<T>(_ type: T.Type = T.self) -> Factory<T>? {
-        defer { globalRecursiveLock.unlock() }
-        globalRecursiveLock.lock()
+        defer { RecursiveLockManager.shared.unlock() }
+        RecursiveLockManager.shared.lock()
         // Perform autoRegistration check
         unsafeCheckAutoRegistration()
         // if we have a registration for this type, then build registration and factory for it

--- a/Sources/Factory/Factory/Resolver.swift
+++ b/Sources/Factory/Factory/Resolver.swift
@@ -54,7 +54,7 @@ extension Resolving {
         // Perform autoRegistration check
         unsafeCheckAutoRegistration()
         // Add register to persist in container, and return factory so user can specialize if desired
-        return Factory(self, key: globalResolverKey, factory).register(factory: factory)
+        return Factory(self, key: GlobalFactoryVariables.shared.globalResolverKey, factory).register(factory: factory)
     }
 
     /// Returns a registered factory for this type from this container. Use this function to set options and previews after the initial
@@ -67,9 +67,9 @@ extension Resolving {
         // Perform autoRegistration check
         unsafeCheckAutoRegistration()
         // if we have a registration for this type, then build registration and factory for it
-        let key = FactoryKey(type: T.self, key: globalResolverKey)
+        let key = FactoryKey(type: T.self, key: GlobalFactoryVariables.shared.globalResolverKey)
         if let factory = manager.registrations[key] as? TypedFactory<Void,T> {
-            return Factory(FactoryRegistration<Void,T>(key: globalResolverKey, container: self, factory: factory.factory))
+            return Factory(FactoryRegistration<Void,T>(key: GlobalFactoryVariables.shared.globalResolverKey, container: self, factory: factory.factory))
         }
         // otherwise return nil
         return nil

--- a/Sources/Factory/Factory/Scopes.swift
+++ b/Sources/Factory/Factory/Scopes.swift
@@ -49,7 +49,7 @@ import Foundation
 ///
 /// If no scope is associated with a given Factory then the scope is considered to be unique and a new instance
 /// of the dependency will be created each and every time that factory is resolved.
-public class Scope {
+public class Scope: @unchecked Sendable {
 
     fileprivate init() {}
 
@@ -171,8 +171,8 @@ extension Scope {
         internal var cache = Cache()
         /// Reset
         public func reset() {
-            defer { globalRecursiveLock.unlock()  }
-            globalRecursiveLock.lock()
+            defer { RecursiveLockManager.shared.unlock()  }
+            RecursiveLockManager.shared.lock()
             cache.reset()
         }
     }

--- a/Sources/Factory/Factory/Scopes.swift
+++ b/Sources/Factory/Factory/Scopes.swift
@@ -74,13 +74,13 @@ public class Scope {
     }
 
     /// Internal function returns unboxed value if it exists
-    fileprivate func unboxed<T>(box: AnyBox?) -> T? {
+    fileprivate func unboxed<T>(box: (any AnyBox)?) -> T? {
         (box as? StrongBox<T>)?.boxed
     }
 
     /// Internal function correctly boxes value depending upon scope type
-    fileprivate func box<T>(_ instance: T) -> AnyBox? {
-        if let optional = instance as? OptionalProtocol {
+    fileprivate func box<T>(_ instance: T) -> (any AnyBox)? {
+        if let optional = instance as? (any OptionalProtocol) {
             if optional.hasWrappedValue {
                 return StrongBox<T>(scopeID: scopeID, timestamp: CFAbsoluteTimeGetCurrent(), boxed: instance)
             }
@@ -131,9 +131,9 @@ extension Scope {
             super.init()
         }
         /// Internal function returns cached value if exists
-        fileprivate override func unboxed<T>(box: AnyBox?) -> T? {
+        fileprivate override func unboxed<T>(box: (any AnyBox)?) -> T? {
             if let box = box as? WeakBox, let instance = box.boxed as? T {
-                if let optional = instance as? OptionalProtocol {
+                if let optional = instance as? (any OptionalProtocol) {
                     if optional.hasWrappedValue {
                         return instance
                     }
@@ -144,8 +144,8 @@ extension Scope {
             return nil
         }
         /// Override function correctly boxes weak cache value
-        fileprivate override func box<T>(_ instance: T) -> AnyBox? {
-            if let optional = instance as? OptionalProtocol {
+        fileprivate override func box<T>(_ instance: T) -> (any AnyBox)? {
+            if let optional = instance as? (any OptionalProtocol) {
                 if let unwrapped = optional.wrappedValue, type(of: unwrapped) is AnyObject.Type {
                     return WeakBox(scopeID: scopeID, timestamp: CFAbsoluteTimeGetCurrent(), boxed: unwrapped as AnyObject)
                 }
@@ -198,12 +198,12 @@ extension Scope {
 extension Scope {
     /// Internal class that manages scope caching for containers and scopes.
     internal final class Cache {
-        typealias CacheMap = [FactoryKey:AnyBox]
+        typealias CacheMap = [FactoryKey:any AnyBox]
         /// Internal support functions
-        @inlinable func value(forKey key: FactoryKey) -> AnyBox? {
+        @inlinable func value(forKey key: FactoryKey) -> (any AnyBox)? {
             cache[key]
         }
-        @inlinable func set(value: AnyBox, forKey key: FactoryKey)  {
+        @inlinable func set(value: any AnyBox, forKey key: FactoryKey)  {
             cache[key] = value
         }
         @inlinable func set(timestamp: Double, forKey key: FactoryKey)  {

--- a/Tests/FactoryTests/FactoryContextTests.swift
+++ b/Tests/FactoryTests/FactoryContextTests.swift
@@ -36,7 +36,7 @@ final class FactoryContextTests: XCTestCase {
     override func tearDown() {
         super.tearDown()
         // restore current arg state
-        FactoryContext.current = FactoryContext()
+        FactoryContext.current.reset()
     }
 
   #if os(macOS)

--- a/Tests/FactoryTests/FactoryDefectTests.swift
+++ b/Tests/FactoryTests/FactoryDefectTests.swift
@@ -236,5 +236,5 @@ fileprivate final class AutoRegisteringContainer: SharedContainer, AutoRegisteri
         test.register { MockServiceN(32) }
         singletonTest.register { MockServiceN(32) }
     }
-    var manager = ContainerManager()
+    let manager = ContainerManager()
 }

--- a/Tests/FactoryTests/FactoryMultithreadingTests.swift
+++ b/Tests/FactoryTests/FactoryMultithreadingTests.swift
@@ -162,7 +162,7 @@ fileprivate final class MultiThreadedContainer: SharedContainer {
     fileprivate var c: Factory<C> { self { C(d: self.d()) } }
     fileprivate var d: Factory<D> { self { D() }.cached }
     fileprivate var e: Factory<E> { self { E() } }
-    var manager = ContainerManager()
+    let manager = ContainerManager()
 }
 
 extension XCTestCase {

--- a/Tests/FactoryTests/MockServices.swift
+++ b/Tests/FactoryTests/MockServices.swift
@@ -181,7 +181,7 @@ extension Container {
 
 // Custom Container
 
-final class CustomContainer: SharedContainer, AutoRegistering {
+final class CustomContainer: @unchecked Sendable, SharedContainer, AutoRegistering {
     static let shared = CustomContainer()
     static var count = 0
     var count = 0
@@ -191,6 +191,7 @@ final class CustomContainer: SharedContainer, AutoRegistering {
         }
         .shared
     }
+    
     var decorated: Factory<MyService> {
         self {
             MyService()
@@ -199,6 +200,7 @@ final class CustomContainer: SharedContainer, AutoRegistering {
             self.count += 1
         }
     }
+    
     var once: Factory<MyService> {
         self {
             MyService()
@@ -209,6 +211,7 @@ final class CustomContainer: SharedContainer, AutoRegistering {
         }
         .once()
     }
+    
     func autoRegister() {
         print("CustomContainer AUTOREGISTERING")
         Self.count = 1

--- a/Tests/FactoryTests/XCTestExtensions.swift
+++ b/Tests/FactoryTests/XCTestExtensions.swift
@@ -55,5 +55,4 @@ extension XCTestCase {
             triggerFatalError = Swift.fatalError
         }
     }
-
 }

--- a/Tests/FactoryTests/XCTestExtensions.swift
+++ b/Tests/FactoryTests/XCTestExtensions.swift
@@ -15,7 +15,7 @@ extension XCTestCase {
         let expectation = self.expectation(description: "expectingFatalError")
         var assertionMessage: String = ""
 
-        triggerFatalError = { (message, _, _) in
+        GlobalFactoryVariables.shared.triggerFatalError = { (message, _, _) in
             assertionMessage = message()
             DispatchQueue.main.async {
                 expectation.fulfill()
@@ -28,7 +28,7 @@ extension XCTestCase {
 
         waitForExpectations(timeout: 0.1) { _ in
             XCTAssertEqual(expectedMessage, assertionMessage)
-            triggerFatalError = Swift.fatalError
+            GlobalFactoryVariables.shared.triggerFatalError = Swift.fatalError
         }
     }
 
@@ -36,7 +36,7 @@ extension XCTestCase {
         let expectation = self.expectation(description: "expectingFatalError")
         var assertionMessage: String = ""
 
-        triggerFatalError = { (message, _, _) in
+        GlobalFactoryVariables.shared.triggerFatalError = { (message, _, _) in
             assertionMessage = message()
             DispatchQueue.main.async {
                 expectation.fulfill()
@@ -52,7 +52,7 @@ extension XCTestCase {
 
         waitForExpectations(timeout: 0.1) { _ in
             XCTAssertEqual(assertionMessage, "")
-            triggerFatalError = Swift.fatalError
+            GlobalFactoryVariables.shared.triggerFatalError = Swift.fatalError
         }
     }
 }


### PR DESCRIPTION
This PR is meant to update the factory library to add conformance to structure concurrency and remove all the warnings linked to upcoming swift feature.

The main goal is to add conformance while not adding any breaking changes.
This was done in several steps:
- Adding flags for swift features
- Encapsulating global variables in sendable namespaces
- Apply change to code to compile with new changes